### PR TITLE
add `falcon_version` fact for linux machines

### DIFF
--- a/lib/facter/falcon_version.rb
+++ b/lib/facter/falcon_version.rb
@@ -1,4 +1,5 @@
 Facter.add(:falcon_version) do
+  confine :kernel => 'Linux'
   # TODO: Verify windows and macos package names = `falcon-sensor`. If they don't use :kernal to set the correct key.
   setcode do
     Puppet::Resource.indirection.find('package/falcon-sensor').to_hash[:ensure]

--- a/lib/facter/falcon_version.rb
+++ b/lib/facter/falcon_version.rb
@@ -1,0 +1,6 @@
+Facter.add(:falcon_version) do
+  # TODO: Verify windows and macos package names = `falcon-sensor`. If they don't use :kernal to set the correct key.
+  setcode do
+    Puppet::Resource.indirection.find('package/falcon-sensor').to_hash[:ensure]
+  end
+end

--- a/spec/unit/facter/falcon_version_spec.rb
+++ b/spec/unit/facter/falcon_version_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'facter'
+require 'facter/falcon_version'
+require 'puppet'
+
+describe :falcon_version, type: :fact do
+  subject(:fact) { Facter.fact(:falcon_version) }
+
+  before :each do
+    Facter.clear
+  end
+
+  it 'returns a value' do
+    # TODO: Not sure how we test this..
+    expect(fact.value).to eq(Puppet::Resource.indirection.find('package/falcon-sensor').to_hash[:ensure])
+  end
+end


### PR DESCRIPTION
This adds the falcon_version fact for linux machines

```
puppet facts falcon_version
{
  "falcon_version": "6.34.0-13109"
}
```