### PR TITLE
add puppet devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,1 @@
-FROM puppet/pdk:latest
-
-# [Optional] Uncomment this section to install additional packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
+FROM ghcr.io/ffalor/puppet:latest

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -8,25 +8,24 @@ https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/pupp
  
 ``` json
 {
-	"name": "Puppet Development Kit (Community)",
+	"name": "Puppet Agent, PDK, Bolt",
 	"dockerFile": "Dockerfile",
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
-
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
-		"rebornix.Ruby"
-	]
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pdk --version",
+		"misogi.ruby-rubocop",
+		"castwide.solargraph"
+	],
+	"settings": {
+		"[ruby]": {
+			"editor.defaultFormatter": "misogi.ruby-rubocop"
+		},
+		"ruby.rubocop.suppressRubocopWarnings": true,
+	},
+	"mounts": [
+		"source=${localWorkspaceFolder},target=/etc/puppetlabs/code/environments/production/modules/falcon,type=bind,consistency=cached",
+	],
+	"postStartCommand": "bundle install"
 }
 ```
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,20 @@
 {
-	"name": "Puppet Development Kit (Community)",
+	"name": "Puppet Agent, PDK, Bolt",
 	"dockerFile": "Dockerfile",
-
-	"settings": {
-		"terminal.integrated.profiles.linux": {
-			"bash": {
-				"path": "bash",
-			}
-		}
-	},
-
+	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
-		"rebornix.Ruby"
-	]
+		"misogi.ruby-rubocop",
+		"castwide.solargraph"
+	],
+	"settings": {
+		"[ruby]": {
+			"editor.defaultFormatter": "misogi.ruby-rubocop"
+		},
+		"ruby.rubocop.suppressRubocopWarnings": true,
+	},
+	"mounts": [
+		"source=${localWorkspaceFolder},target=/etc/puppetlabs/code/environments/production/modules/falcon,type=bind,consistency=cached",
+	],
+	"postStartCommand": "bundle install"
 }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 - rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.4'
+  TargetRubyVersion: '2.7'
   Include:
   - "**/*.rb"
   Exclude:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "puppet.puppet-vscode",
-    "rebornix.Ruby"
+    "misogi.ruby-rubocop",
+    "castwide.solargraph"
   ]
 }

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-resource_api",                                     require: false
+  gem 'puppet-strings', require: false
+  gem 'rubocop', require: false
+  gem 'solargraph', require: false
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]


### PR DESCRIPTION
Adds a puppet devcontainer:

- Mounts workspace to puppet module directory
- Installs important extensions
- Install `puppet-strings`, `solargraph`, and `rubocop` and other required gems via the `gemfile`
- Contains Puppet PDK
- Contains Puppet Agent
- Contains Puppet Bolt