### PR TITLE
add `sensor_download` puppet resource type

### DIFF
--- a/lib/puppet/provider/sensor_download/sensor_download.rb
+++ b/lib/puppet/provider/sensor_download/sensor_download.rb
@@ -1,0 +1,18 @@
+require_relative '../../puppet_x/falconapi'
+
+Puppet::Type.type(:sensor_download).provide(:default) do
+  desc 'Download sensor package using Ruby'
+
+  def create
+    falcon_api = FalconApi.new(falcon_cloud: @resource[:falcon_cloud], bearer_token: @resource[:bearer_token])
+    falcon_api.download_installer(@resource['sha256'], @resource['name'])
+  end
+
+  def destroy
+    File.unlink(@resource[:name])
+  end
+
+  def exists?
+    File.exist?(@resource[:name])
+  end
+end

--- a/lib/puppet/puppet_x/falconapi.rb
+++ b/lib/puppet/puppet_x/falconapi.rb
@@ -17,7 +17,7 @@ class FalconApi
   # - client_id - the client id to generate the bearer token if not provided.
   # - client_secret - the client id to generate the bearer token if not provided.
   def initialize(falcon_cloud:, bearer_token: nil, client_id: nil, client_secret: nil)
-    if client_id.nil? || client_secret.nil? && bearer_token.nil?
+    if (client_id.nil? || client_secret.nil?) && bearer_token.nil?
       raise ArgumentError, 'client_id and client_secret or bearer_token must be provided'
     end
 
@@ -101,7 +101,7 @@ class FalconApi
 
     request = Net::HTTP::Get.new(url_path)
     request['Content-Type'] = 'application/json'
-    request['Authorization'] = "Bearer #{@bearer_token.unwrap}"
+    request['Authorization'] = "Bearer #{@bearer_token}"
 
     resp = @http_client.request(request)
 

--- a/lib/puppet/type/sensor_download.rb
+++ b/lib/puppet/type/sensor_download.rb
@@ -1,0 +1,32 @@
+Puppet::Type.newtype(:sensor_download) do
+  @doc = 'Download the Falcon Sensor'
+
+  ensurable
+
+  newparam(:name) do
+    desc 'The full path to the file.'
+  end
+
+  newparam(:sha256) do
+    desc 'The sha256 of the package to download'
+  end
+
+  newparam(:bearer_token) do
+    desc 'The bearer token used to authenticate with the Falcon API'
+  end
+
+  newparam(:falcon_cloud) do
+    desc 'The falcon cloud URI to use'
+  end
+
+  private
+
+  def set_sensitive_parameters(sensitive_parameters)
+    # Respect sensitive https://tickets.puppetlabs.com/browse/PUP-10950
+    if sensitive_parameters.include?(:bearer_token)
+      sensitive_parameters.delete(:bearer_token)
+      parameter(:bearer_token).sensitive = true
+    end
+    super(sensitive_parameters)
+  end
+end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -45,8 +45,23 @@ class falcon::install (
 
   $info = falcon::sensor_download_info($client_id, $client_secret, $config)
 
-  notify { 'title':
-    message => $info
+  if $facts['falcon_version'] == $info['version'] {
+    $sensor_download_ensure = 'absent'
+  } else {
+    $sensor_download_ensure = 'present'
+  }
+
+  sensor_download { 'Download Sensor Package':
+    ensure       => $sensor_download_ensure,
+    name         => $info['file_path'],
+    sha256       => $info['sha256'],
+    bearer_token => $info['bearer_token'],
+    falcon_cloud => 'api.crowdstrike.com',
+  }
+
+  package { 'falcon-sensor':
+    ensure => $info['version'],
+    source => $info['file_path'],
   }
 }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -56,7 +56,7 @@ class falcon::install (
     name         => $info['file_path'],
     sha256       => $info['sha256'],
     bearer_token => $info['bearer_token'],
-    falcon_cloud => 'api.crowdstrike.com',
+    falcon_cloud => $falcon_cloud,
   }
 
   package { 'falcon-sensor':

--- a/spec/unit/puppet/type/sensor_download_spec.rb
+++ b/spec/unit/puppet/type/sensor_download_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet/type/sensor_download'
+
+RSpec.describe 'the sensor_download type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:sensor_download)).not_to be_nil
+  end
+end


### PR DESCRIPTION
A simple puppet type `sensor_download` that will be used to ensure the package is downloaded when needed.

If the `falcon_version` fact is equal to what we determine should be the desired version then we will ensure the package is removed from the system.

Else we download the package for it to be used by the `package` resource.