### PR TITLE
add acceptance tests using litmus

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,12 @@
 		},
 		"ruby.rubocop.suppressRubocopWarnings": true,
 	},
+	"features": {
+		"docker-in-docker": {
+			"version": "latest"
+		},
+		"sshd": "latest"
+	},
 	"mounts": [
 		"source=${localWorkspaceFolder},target=/etc/puppetlabs/code/environments/production/modules/falcon,type=bind,consistency=cached",
 	],

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,3 +4,7 @@
 fixtures:
   forge_modules:
 #     stdlib: "puppetlabs/stdlib"
+  repositories:
+      facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+      puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+      provision: 'https://github.com/puppetlabs/provision.git'

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,0 +1,125 @@
+name: "PR Testing"
+
+on:
+  pull_request_target:
+      types: [ labeled ]
+      paths:
+        - 'lib/**'
+        - 'manifests/**'
+        - '.github/workflows/pr_test.yml'
+jobs:
+  setup_matrix:
+    if: |
+      github.event_name == 'push' ||
+      github.event.label.name == 'ok-to-test'
+    name: "Setup Test Matrix"
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.get-matrix.outputs.matrix }}
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v2
+    - name: Activate Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "2.7"
+        bundler-cache: true
+    - name: Print bundle environment
+      run: | 
+        bundle env
+    - name: Setup Acceptance Test Matrix
+      id: get-matrix
+      run: |
+        bundle exec matrix_from_metadata_v2 --exclude-platforms '["sles-15","redhat-8", "windows-10", "windows-2016","windows-2019"]'
+    - name: Print matrix JSON
+      run: |
+        echo  ${{ steps.get-matrix.outputs.matrix }}
+  Acceptance:
+    name: "${{matrix.platforms.label}}, ${{matrix.collection}}"
+    if: |
+      github.event_name == 'push' ||
+      github.event.label.name == 'ok-to-test'
+    needs:
+      - setup_matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platforms: ${{ fromJson(needs.setup_matrix.outputs.matrix).platforms }}
+        collection: ${{ fromJson(needs.setup_matrix.outputs.matrix).collection }}
+        include:
+          - platforms.provider: "provision::docker"
+            os: ubuntu-20.04
+          - platforms.label: "Windows-10"
+            os: macos-10.15
+            platforms:
+              label: "Windows-10"
+              provider: "vagrant"
+              image: "StefanScherer/windows_10"
+            collection: "puppet6-nightly"
+          - platforms.label: "Windows-10"
+            os: macos-10.15
+            platforms:
+              label: "Windows-10"
+              provider: "vagrant"
+              image: "StefanScherer/windows_10"
+            collection: "puppet7-nightly"
+
+    steps:
+    - run: |
+        echo 'image=${{ matrix.platforms.image }}'
+        echo 'collection=${{ matrix.collection }}'
+        echo 'label=${{ matrix.platforms.label }}'
+        echo 'provider=${{ matrix.platforms.provider }}'
+    - name: Checkout Source
+      uses: actions/checkout@v2
+    - name: Cache Vagrant boxes
+      if: ${{ matrix.platforms.provider == 'vagrant' }}
+      uses: actions/cache@v2
+      with:
+        path: ~/.vagrant.d/boxes
+        # Since the workflow is adding the vagrant provider to the matrix, we will use
+        # the workflow hash as part of the key.
+        key: ${{ runner.os }}-vagrant-${{ hashFiles('./.github/workflows/pr_test.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-vagrant-
+    - name: Activate Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "2.7"
+        bundler-cache: true
+    - name: Print bundle environment
+      run: |
+        bundle env
+    - name: Provision test environment
+      run: |
+        CI=true bundle exec rake 'litmus:provision[${{matrix.platforms.provider}},${{ matrix.platforms.image }}]'
+
+        if [ -f 'spec/fixtures/litmus_inventory.yaml' ];
+        then
+          FILE='spec/fixtures/litmus_inventory.yaml'
+        elif [ -f 'inventory.yaml' ];
+        then
+          FILE='inventory.yaml'
+        fi
+        sed -e 's/password: .*/password: "[redacted]"/' < $FILE || true
+    - name: Install agent
+      run: |
+        CI=true bundle exec rake 'litmus:install_agent[${{ matrix.collection }}]'
+    - name: Install module
+      run: |
+        CI=true bundle exec rake 'litmus:install_module'
+    - name: Run acceptance tests
+      env:
+        CLIENT_ID: ${{ secrets.LITMUS_CLIENT_ID }}
+        CLIENT_SECRET: ${{ secrets.LITMUS_CLIENT_SECRET }}
+        CID: ${{ secrets.LITMUS_CID }}
+      run: |
+        CI=true bundle exec rake 'litmus:acceptance:parallel'
+    - name: Remove test environment
+      if: ${{ always() }}
+      continue-on-error: true
+      run: |
+        if [[ -f inventory.yaml || -f spec/fixtures/litmus_inventory.yaml ]]; then
+          CI=true bundle exec rake 'litmus:tear_down'
+        fi

--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,10 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-resource_api",                                     require: false
-  gem 'puppet-strings', require: false
-  gem 'rubocop', require: false
-  gem 'solargraph', require: false
+  gem 'puppet-strings',                                          require: false
+  gem 'rubocop',                                                 require: false
+  gem 'solargraph',                                              require: false
+  gem 'puppet_litmus',                                           require: false
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -64,5 +64,3 @@ class falcon::install (
     source => $info['file_path'],
   }
 }
-
-include falcon::install

--- a/metadata.json
+++ b/metadata.json
@@ -2,12 +2,10 @@
   "name": "crowdstrike-falcon",
   "version": "0.1.0",
   "author": "crowdstrike",
-  "summary": "",
+  "summary": "Module to manage CrowdStrike Falcon Sensor",
   "license": "Apache-2.0",
-  "source": "",
-  "dependencies": [
-
-  ],
+  "source": "https://github.com/crowdstrike/puppet-falcon",
+  "dependencies": [],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
@@ -73,15 +71,8 @@
       "operatingsystem": "windows",
       "operatingsystemrelease": [
         "2019",
+        "2016",
         "10"
-      ]
-    },
-    {
-      "operatingsystem": "AIX",
-      "operatingsystemrelease": [
-        "6.1",
-        "7.1",
-        "7.2"
       ]
     }
   ],

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,0 +1,5 @@
+---
+default:
+  provisioner: docker
+  images: 
+    - 'ubuntu:bionic'

--- a/spec/acceptance/falcon_install_spec.rb
+++ b/spec/acceptance/falcon_install_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper_acceptance'
+
+describe 'install falcon' do
+  let(:pp) do
+    <<-MANIFEST
+      class { 'falcon::install':
+        falcon_cloud => 'api.us-2.crowdstrike.com',
+        client_id => Sensitive('#{ENV['CLIENT_ID']}'),
+        client_secret => Sensitive('#{ENV['CLIENT_SECRET']}'),
+        update_policy => 'platform_default'
+      }
+    MANIFEST
+  end
+
+  it 'applies' do
+    apply_manifest(pp)
+  end
+
+  describe package('falcon-sensor') do
+    it { is_expected.to be_installed }
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'puppet_litmus'
+PuppetLitmus.configure!
+
+require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))


### PR DESCRIPTION

This PR adds the required files to start using litmus for acceptance testing

https://github.com/puppetlabs/puppet_litmus

- adds `pr_test.yml` workflow that runs acceptance tests on
  - IMAGES: 
    - `Ubuntu 18.04` and `Ubuntu 20.04`
    - `CentOS 7`
    - `Debian 10` 
    - `Oracle Linux 7`
    - `Scientific 7`
    - `Windows 10`
  - PUPPET VERSION
    - `puppet7-nightly`
    - `puppet6-nightly`

`Linux` images use `docker` and `windows` images use `vagrant`

A very simple acceptance test was setup that simply applies a generic manifests and checks to see if the `CrowdStrike Sensor` was installed