### PR TITLE
fix sensor lookup logic

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       run: |
-        python ./.github/workflows/files/generate_matrix.py -g linux windows
+        python ./.github/workflows/files/generate_matrix.py -g linux
     - name: Print matrix JSON
       run: |
         echo  ${{ steps.get-matrix.outputs.matrix }}
@@ -107,8 +107,9 @@ jobs:
         CLIENT_ID: ${{ secrets.LITMUS_CLIENT_ID }}
         CLIENT_SECRET: ${{ secrets.LITMUS_CLIENT_SECRET }}
         CID: ${{ secrets.LITMUS_CID }}
+        DEBUG: true
       run: |
-        CI=true bundle exec rake 'litmus:acceptance:parallel'
+        CI=true DEBUG=true bundle exec rake 'litmus:acceptance:parallel'
     - name: Remove test environment
       if: ${{ always() }}
       continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+setup_env.sh

--- a/data/kernel/windows.yaml
+++ b/data/kernel/windows.yaml
@@ -1,0 +1,3 @@
+---
+
+falcon::install::sensor_tmp_dir: "C:\\windows\\temp"

--- a/lib/puppet/puppet_x/helper.rb
+++ b/lib/puppet/puppet_x/helper.rb
@@ -4,8 +4,12 @@ require 'json'
 require 'cgi'
 
 # Build the query string used to filter sensor installers
-def build_sensor_installer_query(platform_name:, os_name: nil, version: nil)
+def build_sensor_installer_query(platform_name:, os_name: nil, version: nil, os_version: nil)
   query = "platform:'#{platform_name.downcase}'"
+
+  unless os_version.nil?
+    query += "+os_version:'#{os_version}'"
+  end
 
   unless version.nil?
     query += "+version:'#{version}'"
@@ -18,11 +22,63 @@ def build_sensor_installer_query(platform_name:, os_name: nil, version: nil)
   query
 end
 
-# Grabs the platform name that the falcon api expects
+# Returns the platform name in the format expected by the falcon api
 def platform(scope)
   if scope['facts']['os']['macosx']
     return 'Mac'
   end
 
   scope['facts']['kernel'].capitalize
+end
+
+# Returns the version of the os in the format expected by the falcon api
+def os_version(scope, os_name)
+  if os_name.casecmp('macOS').zero? || os_name.casecmp('windows').zero?
+    return nil
+  end
+
+  if os_name.casecmp('RHEL/CentOS/Oracle').zero?
+    return scope['facts']['os']['release']['major']
+  end
+
+  if os_name.casecmp('Debian').zero?
+    return '9/10/11'
+  end
+
+  if os_name.casecmp('Ubuntu').zero?
+    return '16/18/20'
+  end
+
+  os_release_major = scope['facts']['os']['release']['major']
+
+  if os_name.casecmp('Amazon Linux').zero? && scope['facts']['architecture'].casecmp('arm64').zero?
+    os_release_major + ' - arm64'
+  end
+
+  os_release_major
+end
+
+# Return the OS name in the format expected by the falcon api
+def os_name(scope, platform_name)
+  if platform_name.casecmp('mac').zero?
+    return 'macOS'
+  end
+
+  if platform_name.casecmp('windows').zero?
+    return 'Windows'
+  end
+
+  fact_os_name = scope['facts']['os']['name']
+
+  if fact_os_name.casecmp('Amazon').zero?
+    return 'Amazon Linux'
+  end
+
+  rhel_base = ['RedHat', 'CentOS', 'OracleLinux', 'Scientific', 'Rocky', 'AlmaLinux']
+
+  if rhel_base.any? { |base| fact_os_name.casecmp(base).zero? }
+    return 'RHEL/CentOS/Oracle'
+  end
+
+  fact_os_name
 end

--- a/spec/acceptance/falcon_install_spec.rb
+++ b/spec/acceptance/falcon_install_spec.rb
@@ -13,7 +13,7 @@ describe 'install falcon' do
   end
 
   it 'applies' do
-    apply_manifest(pp)
+    apply_manifest(pp, { catch_failures: true })
   end
 
   describe package('falcon-sensor') do


### PR DESCRIPTION
`sensor_download_info` now picks the correct installer based on the OS version 
`sensor_download_info` now passes the correct os_name for each platform
`sensor_download_info` now returns the falcon sensor version in the same format the OS expects. For example the falcon api may return this version `6.35.1305` for `CentOS7`, but the OS reports `6.34.0-1305.el7` 