### PR TITLE
allow `version_manage` to prevent api calls

### DIFF
--- a/lib/facter/falcon_version.rb
+++ b/lib/facter/falcon_version.rb
@@ -2,6 +2,18 @@ Facter.add(:falcon_version) do
   confine kernel: 'Linux'
   # TODO: Verify windows and macos package names = `falcon-sensor`. If they don't use :kernal to set the correct key.
   setcode do
-    Puppet::Resource.indirection.find('package/falcon-sensor').to_hash[:ensure]
+    pkg_name = 'falcon-sensor'
+    pkg_ensure = Puppet::Resource.indirection.find("package/#{pkg_name}").to_hash[:ensure]
+
+    Puppet.debug("#{pkg_name} returned ensure: #{pkg_ensure}")
+
+    if [:purged, :absent, :undef].include?(pkg_ensure)
+      pkg_ensure = :absent
+    end
+
+    pkg_ensure
+  rescue => exception
+    Puppet.debug("#{pkg_name} returned exception: #{exception}")
+    :absent
   end
 end

--- a/lib/puppet/provider/sensor_download/sensor_download.rb
+++ b/lib/puppet/provider/sensor_download/sensor_download.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:sensor_download).provide(:default) do
 
   def exists?
     falcon_version = Facter.value('falcon_version')
-    installed = falcon_version != :purged
+    installed = [:absent, :purged, :undef, nil].include?(falcon_version) ? false : true
 
     Puppet.debug("version_manage is #{@resource[:version_manage]}")
     Puppet.debug("falcon_version fact returns #{falcon_version}")

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,15 +22,17 @@ class falcon::install {
 
       $info = falcon::sensor_download_info($falcon::client_id, $falcon::client_secret, $config)
 
-      sensor_download { 'Download Sensor Package':
-        ensure         => 'present',
-        version_manage => $falcon::version_manage,
-        version        => $info['version'],
-        file_path      => $info['file_path'],
-        sha256         => $info['sha256'],
-        bearer_token   => $info['bearer_token'],
-        falcon_cloud   => $falcon::falcon_cloud,
-        before         => Package['falcon']
+      if $falcon::version_manage or ($facts['falcon_version'] in ['absent', undef]){
+          sensor_download { 'Download Sensor Package':
+            ensure         => 'present',
+            version_manage => $falcon::version_manage,
+            version        => $info['version'],
+            file_path      => $info['file_path'],
+            sha256         => $info['sha256'],
+            bearer_token   => $info['bearer_token'],
+            falcon_cloud   => $falcon::falcon_cloud,
+            before         => Package['falcon']
+        }
       }
 
       if $falcon::version_manage {

--- a/spec/classes/falcon_spec.rb
+++ b/spec/classes/falcon_spec.rb
@@ -140,6 +140,30 @@ describe 'falcon' do
               end
 
               it { is_expected.to contain_package('falcon').with_ensure('present') }
+
+              context 'when falcon is installed' do
+                let(:facts) do
+                  super().merge(falcon_version: '4.1.0-4404')
+                end
+
+                it { is_expected.not_to contain_sensor_download('Download Sensor Package') }
+              end
+
+              context 'when falcon is not installed' do
+                let(:facts) do
+                  super().merge(falcon_version: 'absent')
+                end
+
+                it { is_expected.to contain_sensor_download('Download Sensor Package') }
+              end
+            end
+
+            context 'when version_manage=true' do
+              let(:params) do
+                super().merge(version_manage: true)
+              end
+
+              it { is_expected.to contain_sensor_download('Download Sensor Package').with_ensure('present') }
             end
           end
 


### PR DESCRIPTION
Move the `version_manage` logic check into the install class. This causes the `api` install method to not call the api at all when the server is already in the desired state. This should allow most deployments to use the `api` install method without risk of hitting API rate limits.

# What changed

`version_manage` now controls rather or not `sensor_download` resource is included in the catalog.

Scenario 1: `version_manage` is `true` the `sensor_download` resource is included in the catalog and will call the CrowdStrike API

Scenario 2: `version_manage` is `false`. If falcon is installed `sensor_download` is not included and will not call the CrowdStrike API. If falcon is not installed `sensor_download` is included and will call the api.
