### PR TITLE
add more images

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -1,31 +1,36 @@
 ---
-
 local:
   provisioner: docker
   images:
-    - 'litmusimage/centos:8'
+    - "litmusimage/centos:8"
 
 linux:
   provisioner: docker
-  images: 
-    - 'litmusimage/centos:7'
-    - 'litmusimage/centos:8'
-    - 'litmusimage/debian:9'
-    - 'litmusimage/debian:10'
-    - 'litmusimage/debian:11'
-    - 'litmusimage/ubuntu:16.04'
-    - 'litmusimage/ubuntu:18.04'
-    - 'litmusimage/ubuntu:20.04'
-    - 'litmusimage/oraclelinux:6'
-    - 'litmusimage/oraclelinux:7'
-    - 'litmusimage/scientificlinux:7'
-    - 'litmusimage/rockylinux:8'
-    - 'litmusimage/almalinux:8'
+  images:
+    - "ghcr.io/ffalor/centos:7"
+    - "ghcr.io/ffalor/centos:stream8"
+    - "ghcr.io/ffalor/centos:stream9"
+    - "ghcr.io/ffalor/debian:9"
+    - "ghcr.io/ffalor/debian:10"
+    - "ghcr.io/ffalor/debian:11"
+    - "ghcr.io/ffalor/ubuntu:16.04"
+    - "ghcr.io/ffalor/ubuntu:18.04"
+    - "ghcr.io/ffalor/ubuntu:20.04"
+    - "ghcr.io/ffalor/ubuntu:22.04"
+    - "ghcr.io/ffalor/oraclelinux:6"
+    - "ghcr.io/ffalor/oraclelinux:7"
+    - "ghcr.io/ffalor/oraclelinux:8"
+    - "ghcr.io/ffalor/scientificlinux:7"
+    - "ghcr.io/ffalor/rockylinux:8"
+    - "ghcr.io/ffalor/rockylinux:9"
+    - "ghcr.io/ffalor/almalinux:8"
+    - "ghcr.io/ffalor/almalinux:9"
+    - "ghcr.io/ffalor/amazonlinux:2"
 
 windows:
   provisioner: vagrant
   images:
-    - 'StefanScherer/windows_10'
+    - "StefanScherer/windows_10"
 
 # Puppet versions to test agaisnt
 collections:


### PR DESCRIPTION
Adds the following images to our pipeline:

- Centos 9
- AlmaLinux 9
- RockyLinux 9
- OracleLinux 8
- Ubuntu 22.04
- AmazonLinux 2

closes #13 