### PR TITLE
Version tracking issues

### DIFF
--- a/lib/puppet/functions/falcon/sensor_download_info.rb
+++ b/lib/puppet/functions/falcon/sensor_download_info.rb
@@ -70,7 +70,7 @@ Puppet::Functions.create_function(:'falcon::sensor_download_info') do
     # 6.25.0-1302 so the below regex is used to make this change.
     # TODO: Check if macos and windows package version needs the same fix
     version = version.gsub(%r{\.(\d+)\.(\d+)}, '.\1.0-\2')
-    version += ".el#{os_version}" if os_name.casecmp('RHEL/CentOS/Oracle').zero?
+    version += ".el#{os_version}" if os_name.casecmp('*RHEL*').zero?
     version += ".amzn#{os_version}" if os_name.casecmp('Amazon Linux').zero?
 
     {

--- a/lib/puppet/provider/sensor_download/sensor_download.rb
+++ b/lib/puppet/provider/sensor_download/sensor_download.rb
@@ -17,17 +17,21 @@ Puppet::Type.type(:sensor_download).provide(:default) do
   end
 
   def exists?
-    falcon_version = Facter.value('falcon')&.fetch('version', :absent)
+    falcon_fact = Facter.value('falcon')
+    Puppet.debug("falcon fact: #{falcon_fact}")
+    # falcon_version = Facter.value('falcon')&.fetch('version', :absent)
+    falcon_version = falcon_fact&.fetch('version', :absent)
 
     installed = [:absent, :purged, :undef, nil].include?(falcon_version) ? false : true
 
     Puppet.debug("version_manage is #{@resource[:version_manage]}")
     Puppet.debug("falcon_version fact returns #{falcon_version}")
     Puppet.debug("Falcon is installed check returns #{installed}")
+    Puppet.debug("target falcon version is #{@resource[:version]}")
 
     # If version_manage is true check if the installed version is equal to the required version
     if @resource[:version_manage]
-      insync = @resource[:version] == Facter.value('falcon_version')
+      insync = @resource[:version] == falcon_version
       Puppet.debug("Desired version is equal to installed version: #{insync}")
       return insync
     end

--- a/lib/puppet/provider/sensor_download/sensor_download.rb
+++ b/lib/puppet/provider/sensor_download/sensor_download.rb
@@ -18,16 +18,15 @@ Puppet::Type.type(:sensor_download).provide(:default) do
 
   def exists?
     falcon_fact = Facter.value('falcon')
-    Puppet.debug("falcon fact: #{falcon_fact}")
-    # falcon_version = Facter.value('falcon')&.fetch('version', :absent)
-    falcon_version = falcon_fact&.fetch('version', :absent)
+    Puppet.debug("Falcon fact: #{falcon_fact}")
+    falcon_version = falcon_fact&.fetch(:version, :absent)
 
     installed = [:absent, :purged, :undef, nil].include?(falcon_version) ? false : true
 
     Puppet.debug("version_manage is #{@resource[:version_manage]}")
     Puppet.debug("falcon_version fact returns #{falcon_version}")
     Puppet.debug("Falcon is installed check returns #{installed}")
-    Puppet.debug("target falcon version is #{@resource[:version]}")
+    Puppet.debug("Desired falcon version is #{@resource[:version]}")
 
     # If version_manage is true check if the installed version is equal to the required version
     if @resource[:version_manage]


### PR DESCRIPTION
Since version 0.1.0, this module has downloaded the `rpm` file with every Puppet run, and starting with 0.3.0, the `package` resource causes errors from `yum`.

This PR is two changes that seem to fix these two issues.