### PR TITLE
fix version lookup issue

### DIFF
--- a/lib/puppet/puppet_x/falconapi.rb
+++ b/lib/puppet/puppet_x/falconapi.rb
@@ -3,8 +3,6 @@ require 'net/http'
 require 'json'
 require 'cgi'
 
-require_relative 'common'
-
 # FalconApi class to interact with the falcon api related to sensor downloads.
 class FalconApi
   attr_accessor :falcon_cloud
@@ -32,7 +30,7 @@ class FalconApi
                     end
     @client_id = client_id
     @client_secret = client_secret
-    @version = module_version
+    @version = '0.5.1'
   end
 
   # Returns the version of the sensor installer for the given policy and platform name.


### PR DESCRIPTION
Fixes #47 

Previous code works fine when installing the module locally, but it looks like when using a puppet server metadata.json is not in the same path

This change hardcodes the version, a better way will be implemented in the future. 