### PR TITLE
Fix issue with s390x support on sensor API

### DIFF
--- a/lib/puppet/functions/falcon/sensor_download_info.rb
+++ b/lib/puppet/functions/falcon/sensor_download_info.rb
@@ -37,7 +37,7 @@ Puppet::Functions.create_function(:'falcon::sensor_download_info') do
     platform_name = platform(scope)
     os_name = os_name(scope, platform_name)
     os_version = os_version(scope, os_name)
-    architecture = scope['facts']['architecture']
+    architecture = scope['facts']['os']['architecture']
 
     falcon_api = FalconApi.new(falcon_cloud: options['falcon_cloud'], client_id: client_id, client_secret: client_secret)
     falcon_api.platform_name = platform_name

--- a/lib/puppet/puppet_x/helper.rb
+++ b/lib/puppet/puppet_x/helper.rb
@@ -13,9 +13,9 @@ def build_sensor_installer_query(platform_name:, os_name: nil, version: nil, os_
 
   unless architecture.nil?
     query += case architecture
-             when ['x86_64', 'amd64']
+             when 'x86_64', 'amd64'
                "+os_version:!~'arm64'+os_version:!~'zLinux'"
-             when ['arm64', 'aarch64', 'arm']
+             when 'arm64', 'aarch64', 'arm'
                "+os_version:~'arm64'"
              when 's390x'
                "+os_version:~'s390x'"

--- a/lib/puppet/puppet_x/helper.rb
+++ b/lib/puppet/puppet_x/helper.rb
@@ -13,7 +13,7 @@ def build_sensor_installer_query(platform_name:, os_name: nil, version: nil, os_
 
   unless architecture.nil?
     query += case architecture
-             when 'x86_64'
+             when ['x86_64', 'amd64']
                "+os_version:!~'arm64'+os_version:!~'zLinux'"
              when ['arm64', 'aarch64', 'arm']
                "+os_version:~'arm64'"

--- a/lib/puppet/puppet_x/helper.rb
+++ b/lib/puppet/puppet_x/helper.rb
@@ -13,7 +13,7 @@ def build_sensor_installer_query(platform_name:, os_name: nil, version: nil, os_
 
   unless architecture.nil?
     query += case architecture
-             when 'x86_64', 'amd64'
+             when 'x86_64', 'amd64', 'x64'
                "+os_version:!~'arm64'+os_version:!~'zLinux'"
              when 'arm64', 'aarch64', 'arm'
                "+os_version:~'arm64'"

--- a/lib/puppet/puppet_x/helper.rb
+++ b/lib/puppet/puppet_x/helper.rb
@@ -12,10 +12,15 @@ def build_sensor_installer_query(platform_name:, os_name: nil, version: nil, os_
   end
 
   unless architecture.nil?
-    query += if architecture.casecmp('arm64').zero?
+    query += case architecture
+             when 'x86_64'
+               "+os_version:!~'arm64'+os_version:!~'zLinux'"
+             when ['arm64', 'aarch64', 'arm']
                "+os_version:~'arm64'"
+             when 's390x'
+               "+os_version:~'s390x'"
              else
-               "+os_version:!~'arm64'"
+               raise Puppet::Error, "Unsupported architecture: #{architecture}"
              end
   end
 


### PR DESCRIPTION
Fixes #65 

This PR fixes an issue introduced by our sensor installer API that deals with supporting a new s390x architecture for the falcon sensor.