### PR TITLE
Update puppet_litmus to 2

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -54,10 +54,10 @@ jobs:
       run: |
         echo ${{ steps.git-vars.outputs.ref}}
         echo ${{ steps.git-vars.outputs.repository}}
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.2"
         bundler-cache: true
     - name: Print bundle environment
       run: | 
@@ -106,10 +106,10 @@ jobs:
         key: ${{ runner.os }}-vagrant-${{ hashFiles('./.github/workflows/pr_acceptance_test.yml') }}
         restore-keys: |
           ${{ runner.os }}-vagrant-
-    - name: Activate Ruby 2.7
+    - name: Activate Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "2.7"
+        ruby-version: "3.2"
         bundler-cache: true
     - name: Print bundle environment
       run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,5 +11,7 @@ on:
         - '.github/workflows/unit-test.yml'
 jobs:
   Spec:
-    uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@a18620f889f9b80be693ceb62fed9067de370c94"
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@f4a6a10198ad1139b984854f2047840cc400f604"
+    with:
+      ruby_version: "3.2"
     secrets: "inherit"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
+ruby '>= 3.1.0'
+
 def location_for(place_or_version, fake_version = nil)
   git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
   file_url_regex = %r{\Afile:\/\/(?<path>.*)}
@@ -14,12 +16,8 @@ def location_for(place_or_version, fake_version = nil)
 end
 
 group :development do
-  gem "json", '= 2.1.0',                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
   gem "facterdb", '~> 1.18',                     require: false
   gem "metadata-json-lint", '~> 3.0',            require: false

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development do
   gem 'webmock', require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
+  gem "puppet_litmus", '~> 2.0', require: false, platforms: [:ruby, :x64_mingw]
   gem "serverspec", '~> 2.41',   require: false
 end
 

--- a/metadata.json
+++ b/metadata.json
@@ -85,7 +85,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "tags": [

--- a/provision.yaml
+++ b/provision.yaml
@@ -35,5 +35,4 @@ windows:
 
 # Puppet versions to test agaisnt
 collections:
-  - puppet7-nightly
   - puppet8-nightly


### PR DESCRIPTION
Try updating puppet_litmus to 2, which requires ruby 3.1+.  So also drop ruby 2 and puppet 7.

I think there are more changes to be made, though.

Fixes https://github.com/CrowdStrike/puppet-falcon/issues/112
